### PR TITLE
Don't use inverted background for owner tag in profile modal header

### DIFF
--- a/OwnerTag.plugin.js
+++ b/OwnerTag.plugin.js
@@ -248,11 +248,23 @@ var ownerTag = function () {};
             .after(addTag)
             .addClass("kawaii-tagged");
 
-        tags = mutationFind(mutation, ".discord-tag");
+        // User profile popout
+        tags = mutationFind(mutation, ".discord-tag")
+            .filter((_, e) => getUserId(e) === ownerId).not(".kawaii-tagged");
 
-        tags.filter((_, e) => getUserId(e) === ownerId).not(".kawaii-tagged")
-            .append($("<span>", {class: "kawaii-tag kawaii-tag-invert"}).text("OWNER"))
-            .addClass("kawaii-tagged");
+        // Small popout
+        if (tags.parent(".username-wrapper").length > 0) {
+            tags.append($("<span>", {class: "kawaii-tag kawaii-tag-invert"})
+                .text("OWNER"))
+                .addClass("kawaii-tagged");
+        }
+
+        // Fullscreen popout (modal)
+        if (tags.parent(".header-info-inner").length > 0) {
+            tags.append($("<span>", {class: "kawaii-tag kawaii-tag"})
+                .text("OWNER"))
+                .addClass("kawaii-tagged");
+        }
 
         prevGuildId = guildId;
     }


### PR DESCRIPTION
Discord has changed the background color of the profile header (after clicking "View Profile") from blurple to white. This commit reverses the colors in the background of the owner tag.

Before:
![a](https://cloud.githubusercontent.com/assets/2908767/25476227/9f9524be-2b8d-11e7-8fbb-86c1fb50dad7.png)

After:
![b](https://cloud.githubusercontent.com/assets/2908767/25476228/9fdf8392-2b8d-11e7-978f-bea90f198bab.png)

Note that the profile header in the small profile popup (after clicking on, for example, a member on the member list) remains blurple:
![c](https://cloud.githubusercontent.com/assets/2908767/25476478/730bcb86-2b8e-11e7-8f44-203d78d8823d.png)


