### PR TITLE
Owner tag is centered vertically

### DIFF
--- a/OwnerTag.plugin.js
+++ b/OwnerTag.plugin.js
@@ -324,6 +324,7 @@ var ownerTag = function () {};
         line-height: 16px;
         -ms-flex-negative: 0;
         flex-shrink: 0;
+        align-self: center;
     }
 
     .compact .kawaii-tag {


### PR DESCRIPTION
There may be a reason the username could be taller, such as if they have an emoji in it. This uses flexbox so simple fix to make sure the owner tag is centered.