### PR TITLE
Fix LineNumbers for latest Discord

### DIFF
--- a/LineNumbers.plugin.js
+++ b/LineNumbers.plugin.js
@@ -164,7 +164,7 @@ var lineNumbers = function () {};
 
     function processCodeBlocks(mutation) {
         mutationFind(mutation, ".hljs").not(":has(ol)")
-            .filter((_, e) => !(settings.ignoreNoLanguage && e.className == "scrollbarGhost-K_3Xa9 scrollbar-11WJwo hljs"))
+            .filter((_, e) => !(settings.ignoreNoLanguage && e.className.endsWith("hljs")))
             .each(function () {
                 this.innerHTML = this.innerHTML.split("\n").map(line => "<li>"+line+"</li>").join("");
             })


### PR DESCRIPTION
Trying to make it future proof.  Only checks for code block styles ending with hljs instead of trying to match a whole style run.  This also allows the plugin to work more nicely with BandagedBD's "Normalize Styles" function since it inserts in additional styles in the middle causing a match fail but still ends with hljs with that as well.

The last PR was closed in error.  Just going to resubmit with a fresh fork.  Fixes #50 