### PR TITLE
Preserve empty lines in code blocks for copy operations.

### DIFF
--- a/LineNumbers.plugin.js
+++ b/LineNumbers.plugin.js
@@ -166,7 +166,7 @@ var lineNumbers = function () {};
         mutationFind(mutation, ".hljs").not(":has(ol)")
             .filter((_, e) => !(settings.ignoreNoLanguage && e.className.endsWith("hljs")))
             .each(function () {
-                this.innerHTML = this.innerHTML.split("\n").map(line => "<li>"+line+"</li>").join("");
+                this.innerHTML = this.innerHTML.split("\n").map(line => "<li>"+line+" </li>").join("");
             })
             .wrapInner($("<ol>").addClass("kawaii-linenumbers"));
     }


### PR DESCRIPTION
When a person copies a code block this ensures that "empty" lines are preserved for that process by adding an intentional space at the end of every line as they are put back.  The end result is consistent with what Discord ends up giving users when this plugin is not active as the copy result from there has an empty space at the end of every line.  The space on empty lines ensures that it gets copied and preserved for the followup paste operation elsewhere.  Fixes #48