### PR TITLE
Updated class reference

### DIFF
--- a/OwnerTag.plugin.js
+++ b/OwnerTag.plugin.js
@@ -201,7 +201,7 @@ var ownerTag = function () {};
     function processServer(mutation) {
         var chat, guildId, ownerId, members, authors, tags;
 
-        chat = $(".chat")[0];
+        chat = $(".chat-3bRxxu")[0];
 
         // Get the ID of the server
         guildId = getGuildId(chat);


### PR DESCRIPTION
Updated the class reference for chat to match the current discord release.  This fixes the tag not showing up.  Fixes #47